### PR TITLE
Use gulp from node_modules instead of global install and renames scenetypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "npm install\r gulp serve",
   "main": "index.html",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "gulp serve"
   },
   "author": "",
   "license": "ISC",

--- a/readme.md
+++ b/readme.md
@@ -6,4 +6,4 @@ Fork code and check out
 
 Open command prompt
 - npm install
-- gulp serve
+- npm start

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,4 +1,4 @@
-import SceneTypes from '/sceneTypes.js';
+import SceneTypes from '/scenetypes.js';
 
 export default class Scene {
 

--- a/src/scenes/endscene.js
+++ b/src/scenes/endscene.js
@@ -1,5 +1,5 @@
 import Scene from '/scene.js';
-import Scenetypes from '/Scenetypes.js';
+import Scenetypes from '/scenetypes.js';
 
 let scene = new Scene();
 let i = 0;

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -4,7 +4,7 @@ import scene03 from "/scenes/scene03.js";
 import scene04 from "/scenes/scene04.js";
 import endscene from "/scenes/endscene.js";
 import Music from "/music/music.js";
-import SceneTypes from "/Scenetypes.js";
+import SceneTypes from "/scenetypes.js";
 
 let sketch = function(p) {
     let sequence = [scene01, scene02, scene03, scene04, endscene];


### PR DESCRIPTION
This uses gulp installed in node_modules so you don't have to install it globally.

And Renames sceneTypes/SceneTypes/scenetypes import